### PR TITLE
internal/repo/memdb: Config struct is empty 

### DIFF
--- a/review/internal/repository/memdb/memdb.go
+++ b/review/internal/repository/memdb/memdb.go
@@ -6,8 +6,6 @@ import (
 	"github.com/zalgonoise/eljoth-go-code-review/coupon_service/internal/discount"
 )
 
-type Config struct{}
-
 type repository interface {
 	FindByCode(string) (*discount.Coupon, error)
 	Save(discount.Coupon) error


### PR DESCRIPTION
Removed the `Config` struct completely, as it was unused.

Closes #7