### PR TITLE
internal/repo/memdb: New function is not initializing the Repository's map element 

### DIFF
--- a/review/internal/repository/memdb/memdb.go
+++ b/review/internal/repository/memdb/memdb.go
@@ -15,7 +15,9 @@ type CouponsRepository struct {
 }
 
 func New() *CouponsRepository {
-	return &CouponsRepository{}
+	return &CouponsRepository{
+		entries: make(map[string]discount.Coupon),
+	}
 }
 
 func (r *CouponsRepository) FindByCode(code string) (*discount.Coupon, error) {


### PR DESCRIPTION
Initialized the map within the `New()` function.

Closes #11